### PR TITLE
fix error when VT_APIKEY ENV var is set

### DIFF
--- a/sublist3r2.py
+++ b/sublist3r2.py
@@ -678,10 +678,12 @@ class Virustotal(enumratorBaseThreaded):
         base_url = 'https://www.virustotal.com/api/v3/domains/{domain}/subdomains'
         self.engine_name = "Virustotal"
         if os.getenv("VT_APIKEY") is None:
-                 VT_APIKEY=input(B + "[+] Enter VirusTotal API key, press Enter for none: " + W)
-                 VT_APIKEY=VT_APIKEY.strip()
-                 if VT_APIKEY != "":
-                     os.environ["VT_APIKEY"]=(VT_APIKEY)
+            VT_APIKEY=input(B + "[+] Enter VirusTotal API key, press Enter for none: " + W)
+            VT_APIKEY=VT_APIKEY.strip()
+            if VT_APIKEY != "":
+                os.environ["VT_APIKEY"]=(VT_APIKEY)
+        else:
+            VT_APIKEY = os.getenv("VT_APIKEY")
         os.environ["VT_APIKEY"]=(VT_APIKEY)
         self.apikey = os.getenv('VT_APIKEY', None)
         self.q = q


### PR DESCRIPTION
Fixes error
```sh
UnboundLocalError: local variable 'VT_APIKEY' referenced before assignment`
```

This occurs when run with the `VT_APIKEY` ENV var set
e.g.
```sh
VT_APIKEY=1234abcdxxxx python3 sublist3r2.py -v -d example.com
# OR
export VT_APIKEY=1234abcdxxxx
python3 sublist3r2.py -v -d example.com
```